### PR TITLE
Do not log auth token to command line

### DIFF
--- a/pyfactorybridge/__init__.py
+++ b/pyfactorybridge/__init__.py
@@ -155,7 +155,7 @@ class API:
             else:
                 logging.error("Passwordless login failed. Using no authentication.")
 
-        logging.info(f"API initialized with auth token: {self.auth}")
+        logging.info("API initialized")
 
     def __auth_from_password(
         self, Password, MinimumPrivilegeLevel="Administrator"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pyfactorybridge"
-version = "1.0.1"
+version = "1.0.2"
 description = "Wrapper around the Satisfactory Dedicated Server HTTP API"
 authors = ["Jayy001 <github@skii.dev>"]
 license = "MIT"


### PR DESCRIPTION
Hi @Jayy001 great project :+1: 

We are using Version 1.0.1 in this project: [satisfactory-bot](https://github.com/ekeih/satisfactory-bot/pull/141).

While it works as expected, we have noticed that the API Token is logged in its entirety. This means the API token is exposed to anyone who has access to the log.

This PR removes the API token from the log output. I also removed the `with auth token` string because it looks like line 158 is run for the other auth methods as well. Line 141 already makes it visible in the log that an API token was used.

Thanks for providing this library 🙏 